### PR TITLE
python3: Added the latest python 3.6

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,7 +113,9 @@ default['racket']['url'] = "https://download.racket-lang.org/releases/#{default[
 
 # Python 2 & 3
 default['poise-python']['install_python2'] = true
-default['poise-python']['install_python3'] = true
+default['poise-python']['install_python3'] = false
+
+default['python3']['version'] = 3.6
 
 default['python']['ml_home'] = '/var/ml/python'
 default['python3']['ml_home'] = '/var/ml/python3'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -341,6 +341,20 @@ end
 ## Install Python 2 & 3
 include_recipe 'poise-python'
 
+## Install Python 3.6
+apt_repository 'latest-python3' do
+    uri        'ppa:jonathonf/python-3.6'
+end
+
+package 'python' + node['python3']['version']
+
+alternatives 'python3 alternatives' do
+  link_name 'python3'
+  path '/usr/bin/python' + node['python3']['version']
+  priority 100
+  action :install
+end
+
 ## Install Python 2 packages
 python_runtime '2'
 python_package node[:python][:additional_libraries]


### PR DESCRIPTION
Since the default python3 installed in Ubuntu is v3.5, the installation
is done via the `jonathonf/python-3.6` PPA and
`['poise-python']['install_python3']` is set to false

fixes: https://hackerrank.atlassian.net/browse/HFWE-867
