### PR TITLE
clojure: Update clojurec to 1.9

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -172,6 +172,7 @@ default['ocaml']['home'] = '/usr/local/lib/ocaml'
 default['ocaml']['additional_libraries'] = %w(core async core_extended ocamlfind).join(" ")
 
 # Clojure
+default['clojure']['version'] = '1.9.0.381'
 default['clojure']['additional_libraries'] = ['https://search.maven.org/remotecontent?filepath=org/clojure/clojure/1.9.0/clojure-1.9.0.jar',
 	'https://search.maven.org/remotecontent?filepath=org/clojure/spec.alpha/0.1.143/spec.alpha-0.1.143.jar',
 	'https://repo1.maven.org/maven2/org/clojure/data.int-map/0.2.4/data.int-map-0.2.4.jar',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -172,7 +172,6 @@ default['ocaml']['home'] = '/usr/local/lib/ocaml'
 default['ocaml']['additional_libraries'] = %w(core async core_extended ocamlfind).join(" ")
 
 # Clojure
-default['clojure']['version'] = '1.9.0.381'
 default['clojure']['additional_libraries'] = ['https://search.maven.org/remotecontent?filepath=org/clojure/clojure/1.9.0/clojure-1.9.0.jar',
 	'https://search.maven.org/remotecontent?filepath=org/clojure/spec.alpha/0.1.143/spec.alpha-0.1.143.jar',
 	'https://repo1.maven.org/maven2/org/clojure/data.int-map/0.2.4/data.int-map-0.2.4.jar',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -172,6 +172,8 @@ default['ocaml']['home'] = '/usr/local/lib/ocaml'
 default['ocaml']['additional_libraries'] = %w(core async core_extended ocamlfind).join(" ")
 
 # Clojure
+default['leiningen']['home'] = "/home/vagrant"
+default['leiningen']['user'] = "ubuntu"
 default['clojure']['additional_libraries'] = ['https://search.maven.org/remotecontent?filepath=org/clojure/clojure/1.9.0/clojure-1.9.0.jar',
 	'https://search.maven.org/remotecontent?filepath=org/clojure/spec.alpha/0.1.143/spec.alpha-0.1.143.jar',
 	'https://repo1.maven.org/maven2/org/clojure/data.int-map/0.2.4/data.int-map-0.2.4.jar',

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,6 +19,7 @@ depends 'nodejs'
 depends 'php'
 depends 'ruby_build'
 depends 'poise-python'
+depends 'lein'
 
 # The `issues_url` points to the location where issues for this cookbook are
 # tracked.  A `View Issues` link will be displayed on this cookbook's page when

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -717,7 +717,15 @@ node[:clojure][:additional_libraries]. each do |library|
     source library
   end
 end
-package 'clojure1.6'
+
+execute "install-clojure-#{node[:clojure][:version]}" do
+  user "root"
+  command <<-EOH
+    curl -O https://download.clojure.org/install/linux-install-#{node[:clojure][:version]}.sh
+    chmod +x linux-install-#{node[:clojure][:version]}.sh
+    sudo ./linux-install-#{node[:clojure][:version]}.sh
+  EOH
+end
 
 ## Install Perl
 # # Upgrade perl

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -718,14 +718,7 @@ node[:clojure][:additional_libraries]. each do |library|
   end
 end
 
-execute "install-clojure-#{node[:clojure][:version]}" do
-  user "root"
-  command <<-EOH
-    curl -O https://download.clojure.org/install/linux-install-#{node[:clojure][:version]}.sh
-    chmod +x linux-install-#{node[:clojure][:version]}.sh
-    sudo ./linux-install-#{node[:clojure][:version]}.sh
-  EOH
-end
+include_recipe 'lein::default'
 
 ## Install Perl
 # # Upgrade perl


### PR DESCRIPTION
Even though the clojure 1.9 jar file was downloaded from maven central
in

  f00a12d5 attributes: Added java9, updated packages

The Clojurec version still remains 1.6, which is updated to 1.9

fixes: #6 ("Update clojurec to 1.9")
