### PR TITLE
ruby: Download ruby cookbook from source

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,4 @@
+source 'https://supermarket.chef.io'
+
+metadata
+cookbook 'ruby_build', git: 'git://github.com/sous-chefs/ruby_build.git'


### PR DESCRIPTION
The latest ruby_build supports Ubuntu 18.04 dependencies[1], which is not
present in the latest ruby_build release, so download `ruby_build` from
source as of now

[1]: 78e748c Ubuntu 18.04 to use libgdbm5 and libssl1.0-dev
from sous-chefs/ruby_build
